### PR TITLE
Add xafron logo to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
                 <div class="flex items-center">
-                    <span class="font-bold text-2xl gradient-text">Xafron</span>
+                    <img src="./Xafron%20logo.png" alt="Xafron logo" class="h-8 w-auto" />
                 </div>
                 <div class="hidden md:block">
                     <div id="top-nav" class="ml-10 flex items-baseline space-x-4">


### PR DESCRIPTION
Replaced the text brand in the navigation with the `Xafron logo.png` image to display the provided logo on the website.

---
<a href="https://cursor.com/background-agent?bcId=bc-469aa151-a72b-4473-a3fa-bbeaca73e8dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-469aa151-a72b-4473-a3fa-bbeaca73e8dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

