### PR TITLE
Add xafron logo to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
                 <div class="flex items-center">
+                    <img src="Xafron%20logo.png" alt="Xafron logo" class="h-8 w-auto mr-3" />
                     <span class="font-bold text-2xl gradient-text">Xafron</span>
                 </div>
                 <div class="hidden md:block">


### PR DESCRIPTION
Add Xafron logo image to the header next to the Xafron name for all tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b7efd6a-f544-44b3-87df-4dadd0dee2de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b7efd6a-f544-44b3-87df-4dadd0dee2de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

